### PR TITLE
Add email validator

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,14 @@
 from flask import Flask, request, jsonify
 from googletrans import Translator
+import re
 
 app = Flask(__name__)
 translator = Translator()
 #note1
+
+def is_valid_email(email: str) -> bool:
+    pattern = r"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$"
+    return re.match(pattern, email) is not None
 @app.route('/')
 def index():
     with open("index.html", "r", encoding="utf-8") as f:
@@ -15,6 +20,14 @@ def translate():
     text = data.get('text', '')
     translated = translator.translate(text, src='ko', dest='en')
     return jsonify({'translated': translated.text})
+
+
+@app.route('/check_email', methods=['POST'])
+def check_email():
+    data = request.get_json()
+    email = data.get('email', '')
+    result = '적합' if is_valid_email(email) else '부적합'
+    return jsonify({'result': result})
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/index.html
+++ b/index.html
@@ -13,6 +13,13 @@
     </form>
     <div id="result"></div>
 
+    <h2>이메일 형식 검사</h2>
+    <form id="email-form">
+        <input type="text" id="email-input" placeholder="이메일을 입력하세요" />
+        <button type="submit">검사하기</button>
+    </form>
+    <div id="email-result"></div>
+
     <script>
         document.getElementById('translate-form').addEventListener('submit', async (e) => {
             e.preventDefault();
@@ -24,6 +31,18 @@
             });
             const data = await response.json();
             document.getElementById('result').innerText = data.translated;
+        });
+
+        document.getElementById('email-form').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const email = document.getElementById('email-input').value;
+            const response = await fetch('/check_email', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({ email })
+            });
+            const data = await response.json();
+            document.getElementById('email-result').innerText = data.result;
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add an email check form to the frontend
- create `is_valid_email` helper and endpoint in Flask app

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6856aed84c4c832bb8d1ab2340ca0b2b